### PR TITLE
TEL 2129 metrics prefix

### DIFF
--- a/telemetry/telescope_ec2_age/__init__.py
+++ b/telemetry/telescope_ec2_age/__init__.py
@@ -5,3 +5,4 @@ warnings.filterwarnings("ignore", category=PythonDeprecationWarning)
 
 APP_NAME = 'telescope-ec2-age'
 APP_VERSION = "0.1.0"
+METRICS_PREFIX = "telemetry.telescope.ec2.age"

--- a/telemetry/telescope_ec2_age/send_graphite_message.py
+++ b/telemetry/telescope_ec2_age/send_graphite_message.py
@@ -1,4 +1,6 @@
 import graphyte
+
+from telemetry.telescope_ec2_age import METRICS_PREFIX
 from telemetry.telescope_ec2_age.logger import get_app_logger
 
 logger = get_app_logger()
@@ -18,7 +20,7 @@ def publish_asgs_to_graphite(autoscaling_groups_data, graphite_host):
 
 
 def send_asg_data(asg, age, graphite_host):
-    graphyte.init(graphite_host, prefix='sam')
+    graphyte.init(graphite_host, prefix=METRICS_PREFIX)
     graphyte.send('asg.' + asg + '.' + asg + '.asg-age-days', age)
 
 
@@ -31,7 +33,7 @@ def publish_amis_to_graphite(images_data, graphite_host):
 
 
 def send_ami_data(asg, ami, age, graphite_host):
-    graphyte.init(graphite_host, prefix='sam')
+    graphyte.init(graphite_host, prefix=METRICS_PREFIX)
     graphyte.send('asg.' + asg + '.' + ami + '.ami-age-days', age)
 
 
@@ -43,5 +45,5 @@ def publish_instances_to_graphite(instances_data, graphite_host):
 
 
 def send_instance_data(asg, instance, age, graphite_host):
-    graphyte.init(graphite_host, prefix='sam')
+    graphyte.init(graphite_host, prefix=METRICS_PREFIX)
     graphyte.send('asg.' + asg + '.' + instance + '.instance-age-days', age)

--- a/tests/test_send_graphite_message.py
+++ b/tests/test_send_graphite_message.py
@@ -1,0 +1,9 @@
+from telemetry.telescope_ec2_age.send_graphite_message import remove_asg_suffix_code
+
+
+def test_remove_asg_suffix_code():
+    asg_name = "classic-services-admin-asg-20180820125956688700000007"
+    expected_result = "classic-services-admin"
+
+    result = remove_asg_suffix_code(asg_name)
+    assert result == expected_result


### PR DESCRIPTION
- TEL-2129 Refactor to use namespaced packages
- TEL-2129 Add Dockerfile
- TEL-2129 Remove type hints
- TEL-2129 Add new make target "setup"
- TEL-2129 Pass AWS credentials to the Docker container
- TEL-2129 Remove self arg from desc_images.dictionary_handler_assign()
- Delete .python-version
- TEL-2129 Support for setting the log_level from the CLI
- TEL-2129 Make the graphite hostname configurable
- TEL-2129 Add SSH tunnel creation to the README
- Added make cmd for pytest
- Updated README with available action for test-py35 calling pytest
- TEL-2129 add metrics prefix
